### PR TITLE
When the tags data is not supplied, it should default to an empty string...

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -150,7 +150,7 @@ abstract class ImageController
         $image->setCaption($caption);
         $image->setContent(fopen($file->getPathname(), 'r'));
         $image->setMimeType($file->getClientMimeType());
-        $image->setTags(explode(',', $request->get('tags', array())));
+        $image->setTags(explode(',', $request->get('tags', '')));
 
         $this->manager->persist($image);
 


### PR DESCRIPTION
..., not an empty array, as it's passed into explode()
