### PR TITLE
Use the JMS Serializer to serialize the image objects

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -161,17 +161,10 @@ abstract class ImageController
 
     private function processResults($images, $offset)
     {
-        $data = array();
-
-        foreach ($images as $image) {
-            $url = $this->router->generate('symfony_cmf_create_image_display', array('name' => $this->getNameFromId($image->getId())), true);
-            $data[] = array('url' => $url, 'alt' => $image->getCaption());
-        }
-
         $data = array(
             'offset' => $offset,
-            'total' => count($data),
-            'assets' => $data,
+            'total' => count($images),
+            'assets' => $images
         );
 
         $view = View::create($data);

--- a/Resources/config/image.xml
+++ b/Resources/config/image.xml
@@ -4,6 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="symfony_cmf_create.handler_class">Symfony\Cmf\Bundle\CreateBundle\Serializer\Handler</parameter>
+    </parameters>
+
     <services>
 
         <service id="symfony_cmf_create.image.controller" class="%symfony_cmf_create.image.controller_class%">
@@ -14,6 +18,11 @@
             <argument>%symfony_cmf_create.image.model_class%</argument>
             <argument>%symfony_cmf_create.role%</argument>
             <argument type="service" id="security.context" on-invalid="ignore"/>
+        </service>
+
+        <service id="symfony_cmf_create.serializer.handler" class="%symfony_cmf_create.handler_class%" public="true">
+            <tag name="jms_serializer.handler" type="%symfony_cmf_create.image.model_class%" direction="serialization" format="json" method="serializeImageToJson" />
+            <argument type="service" id="router"/>
         </service>
 
     </services>

--- a/Serializer/Handler.php
+++ b/Serializer/Handler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\CreateBundle\Serializer;
+
+use JMS\Serializer\JsonSerializationVisitor;
+use Symfony\Cmf\Bundle\CreateBundle\Document\Image;
+use Symfony\Component\Routing\RouterInterface;
+
+class Handler
+{
+
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    protected function getNameFromId($id)
+    {
+        $path = explode('/', $id);
+        return array_pop($path);
+    }
+
+    /**
+     * Handles the serialization of an Image object
+     *
+     * @param \JMS\Serializer\JsonSerializationVisitor $visitor
+     * @param \Symfony\Cmf\Bundle\CreateBundle\Document\Image $image
+     * @return array
+     */
+    public function serializeImageToJson(JsonSerializationVisitor $visitor, Image $image)
+    {
+        $url = $this->router->generate('symfony_cmf_create_image_display', array('name' => $this->getNameFromId($image->getId())), true);
+        return array('id' => $image->getId(), 'url' => $url, 'alt' => $image->getCaption());
+    }
+
+}


### PR DESCRIPTION
I'd recon, since [we're requiring the JMS Serializer Bundle](https://github.com/symfony-cmf/CreateBundle/blob/master/composer.json#L21), we might as well start using it.

This PR has one loose end which I'll fix if this PR is going to be pulled: I had to copy the protected "getNameFromImage" method from the controller. Probably this (and some other) method should be moved away into it's own service.

This allows me to extend the Handler and easily add some extra fields to the serialized data (caption, width, height of the image)
