### PR TITLE
Allow slash in image routes

### DIFF
--- a/Resources/config/routing/image.xml
+++ b/Resources/config/routing/image.xml
@@ -13,6 +13,7 @@
     <route id="symfony_cmf_create_image_display" pattern="/symfony-cmf/create/image/{name}">
         <default key="_controller">symfony_cmf_create.image.controller:displayAction</default>
         <requirement key="_method">GET</requirement>
+        <requirement key="name">.+</requirement>
     </route>
 
     <route id="symfony_cmf_create_image_search" pattern="/symfony-cmf/create/image/search/">


### PR DESCRIPTION
Nevermind the way the image has been uploaded, it can be stocked in a subfolder.
