### PR TITLE
Fix routes order

### DIFF
--- a/Resources/config/routing/image.xml
+++ b/Resources/config/routing/image.xml
@@ -9,13 +9,6 @@
         <default key="_format">json</default>
         <requirement key="_method">POST</requirement>
     </route>
-
-    <route id="symfony_cmf_create_image_display" pattern="/symfony-cmf/create/image/{name}">
-        <default key="_controller">symfony_cmf_create.image.controller:displayAction</default>
-        <requirement key="_method">GET</requirement>
-        <requirement key="name">.+</requirement>
-    </route>
-
     <route id="symfony_cmf_create_image_search" pattern="/symfony-cmf/create/image/search/">
         <default key="_controller">symfony_cmf_create.image.controller:searchAction</default>
         <default key="_format">json</default>
@@ -32,5 +25,11 @@
         <default key="_controller">symfony_cmf_create.image.controller:listAction</default>
         <default key="_format">json</default>
         <requirement key="_method">GET</requirement>
+    </route>
+
+    <route id="symfony_cmf_create_image_display" pattern="/symfony-cmf/create/image/{name}">
+        <default key="_controller">symfony_cmf_create.image.controller:displayAction</default>
+        <requirement key="_method">GET</requirement>
+        <requirement key="name">.+</requirement>
     </route>
 </routes>


### PR DESCRIPTION
My previous PR broke other image routes as the route was cathing all of them. Sorry for that. This one is to fix that (by changing the order of route definitions).
