### PR TITLE
Error: OutOfBoundsException: The index "3" is not in the range [0, 2].

### DIFF
--- a/DependencyInjection/SymfonyCmfCreateExtension.php
+++ b/DependencyInjection/SymfonyCmfCreateExtension.php
@@ -33,7 +33,7 @@ class SymfonyCmfCreateExtension extends Extension
             if (is_string($config['phpcr_odm'])) {
                 $documentManagerName = $config['phpcr_odm'];
                 $phpcr_odm = $container->getDefinition('symfony_cmf_create.object_mapper');
-                $phpcr_odm->replaceArgument(3, $documentManagerName);
+                $phpcr_odm->replaceArgument(2, $documentManagerName);
             }
 
             $container->setParameter($this->getAlias().'.manager_name', $documentManagerName);


### PR DESCRIPTION
Bug: 3rd argument index is 2 (0,1,2)

Reproduce: set odm document manager name in symfony_cmf_create.phpcr_odm config parameter.

Error:
OutOfBoundsException: The index "3" is not in the range [0, 2].
at Definition->replaceArgument('3', 'cms') in .../Symfony/Cmf/Bundle/CreateBundle/DependencyInjection/SymfonyCmfCreateExtension.php line 36
