### PR TITLE
Git submodules doesn't work in dist-installation

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -2,34 +2,48 @@
 
 namespace Symfony\Cmf\Bundle\CreateBundle\Composer;
 
-use Symfony\Component\ClassLoader\ClassCollectionLoader;
-use Symfony\Component\Process\Process;
-use Symfony\Component\Process\PhpExecutableFinder;
-
 /**
  * A hack to work around the missing support for js assets in composer
  *
- * @see http://groups.google.com/group/composer-dev/browse_thread/thread/e9e2f7d919aadfec
+ * @see    http://groups.google.com/group/composer-dev/browse_thread/thread/e9e2f7d919aadfec
  *
  * @author David Buchmann
  */
-class ScriptHandler
-{
-    public static function initSubmodules($event)
-    {
+class ScriptHandler {
+    /**
+     * @param \Composer\Script\CommandEvent $event
+     * @throws \RuntimeException
+     */
+    public static function initSubmodules ($event) {
         $status = null;
         $output = array();
         $dir = getcwd();
-        chdir(__DIR__.DIRECTORY_SEPARATOR.'..');
-        exec('git submodule sync', $output, $status);
-        if ($status) {
-            chdir($dir);
-            die("Running git submodule sync failed with $status\n");
+        chdir(__DIR__ . DIRECTORY_SEPARATOR . '..');
+        if (file_exists(__DIR__ . '/../.git')) {
+            exec('git submodule sync', $output, $status);
+            if ($status) {
+                chdir($dir);
+                throw new \RuntimeException("Running 'git submodule sync failed' with $status");
+            }
+            exec('git submodule update --init --recursive', $output, $status);
+            if ($status) {
+                chdir($dir);
+                throw new \RuntimeException("Running 'git submodule --init --recursive' failed with $status");
+            }
+        } else {
+            $modules = parse_ini_file(__DIR__ . '/../.gitmodules', true);
+            foreach ($modules as $module) {
+                $path = $module['path'];
+                $url = $module['url'];
+
+                file_exists($path) and rmdir($path);
+                exec("git clone --recursive -- $url $path", $output, $status);
+                if ($status) {
+                    chdir($dir);
+                    throw new \RuntimeException("Running 'git clone -- $url $path' failed with $status");
+                }
+            }
         }
-        exec('git submodule update --init --recursive', $output, $status);
         chdir($dir);
-        if ($status) {
-            die("Running git submodule --init --recursive failed with $status\n");
-        }
     }
 }


### PR DESCRIPTION
My second concern about the submodule handling :wink:

When the create-bundle is installed via Composer with the `--prefer-dist` the composer script-handler fails, because it is not a git repository anymore.
