### PR TITLE
changed dependencies to allow all subsequent Symfony 2.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev",
-        "symfony/assetic-bundle": ">=2.1,<2.3-dev",
-        "kriswallsmith/assetic": "~1.1.0-alpha4@alpha",
+        "symfony/framework-bundle": "~2.1",
+        "symfony/assetic-bundle": "~2.1",
         "friendsofsymfony/rest-bundle": "0.12.*",
         "jms/serializer-bundle": "0.12.*",
         "midgard/createphp": "dev-master"


### PR DESCRIPTION
I'd suggest it should be possible now to say that this bundle should now be able to support all remaining Symfony 2.x releases - this change specifies that (and allows use of the 2.3.0 version of symfony/assetic-bundle which has already been tagged). It also removes the direct specification of kriswallsmith/assetic, letting the specification fall back to that given by the symfony/assetic-bundle package.
