### PR TITLE
Renaming the bundle name breaks existing hardcoded assets paths

### DIFF
--- a/Resources/public/css/createStyle.css
+++ b/Resources/public/css/createStyle.css
@@ -1,7 +1,7 @@
 /* Create toolbar */
 /******************/
 a.create-ui-toggle {
-    background-image: url("/bundles/symfonycmfcreate/img/createbundle.png");
+    background-image: url("/bundles/cmfcreate/img/createbundle.png");
 }
 
 /* General contenteditable before editing */

--- a/Resources/public/css/halloCmfStyle.css
+++ b/Resources/public/css/halloCmfStyle.css
@@ -29,7 +29,7 @@ body > .hallotoolbar {
 }
 
 .hallotoolbar .halloButtonrow-2 .ui-buttonset {
-    background: url('/bundles/symfonycmfcreate/img/stripe.png') no-repeat right 5px;
+    background: url('/bundles/cmfcreate/img/stripe.png') no-repeat right 5px;
     padding: 0 6px 0 5px;
 }
 
@@ -68,25 +68,25 @@ body > .hallotoolbar {
 
 /* Image dialog */
 .halloimage-dialog .tabs li {
-    background: #01add2 url('/bundles/symfonycmfcreate/img/divider.png') no-repeat right;
+    background: #01add2 url('/bundles/cmfcreate/img/divider.png') no-repeat right;
 }
 
 .halloimage-dialog .tabs li.halloimage-tab-suggestions span {
-    background: url('/bundles/symfonycmfcreate/img/tabicon_suggestions.png') no-repeat left;
+    background: url('/bundles/cmfcreate/img/tabicon_suggestions.png') no-repeat left;
 }
 .halloimage-dialog .tabs li.halloimage-tab-search span {
-    background: url('/bundles/symfonycmfcreate/img/tabicon_search.png') no-repeat left;
+    background: url('/bundles/cmfcreate/img/tabicon_search.png') no-repeat left;
 }
 .halloimage-dialog .tabs li.halloimage-tab-upload span {
-    background: url('/bundles/symfonycmfcreate/img/tabicon_upload.png') no-repeat left;
+    background: url('/bundles/cmfcreate/img/tabicon_upload.png') no-repeat left;
 }
 
 .halloimage-dialog .tab-activeIndicator {
-    background: url('/bundles/symfonycmfcreate/img/arrow.png');
+    background: url('/bundles/cmfcreate/img/arrow.png');
 }
 
 .halloimage-dialog .rotationWrapper .hintArrow {
-    background: transparent url('/bundles/symfonycmfcreate/img/drop_left.png') no-repeat -2px -2px;
+    background: transparent url('/bundles/cmfcreate/img/drop_left.png') no-repeat -2px -2px;
 }
 
 /* Drag n Drop */
@@ -159,7 +159,7 @@ body > .hallotoolbar {
     position: relative;
     top: 25px;
     left: 25px;
-    background: rgba(0,0,0,0.8) url('/bundles/symfonycmfcreate/img/trash.png') no-repeat 12px 12px;
+    background: rgba(0,0,0,0.8) url('/bundles/cmfcreate/img/trash.png') no-repeat 12px 12px;
     border-radius: 10px;
     cursor: none;
 }

--- a/Resources/views/includecssfiles.html.twig
+++ b/Resources/views/includecssfiles.html.twig
@@ -1,12 +1,12 @@
 {% stylesheets filter='cssrewrite'
-    'bundles/symfonycmfcreate/vendor/create/themes/midgard-tags/tags.css'
-    'bundles/symfonycmfcreate/vendor/create/themes/create-ui/css/create-ui.css'
-    'bundles/symfonycmfcreate/vendor/create/examples/font-awesome/css/font-awesome.css'
-    'bundles/symfonycmfcreate/vendor/create/themes/midgard-notifications/midgardnotif.css'
+    'bundles/cmfcreate/vendor/create/themes/midgard-tags/tags.css'
+    'bundles/cmfcreate/vendor/create/themes/create-ui/css/create-ui.css'
+    'bundles/cmfcreate/vendor/create/examples/font-awesome/css/font-awesome.css'
+    'bundles/cmfcreate/vendor/create/themes/midgard-notifications/midgardnotif.css'
 
-    'bundles/symfonycmfcreate/css/halloCmfStyle.css'
-    'bundles/symfonycmfcreate/css/createStyle.css'
-    'bundles/symfonycmfcreate/css/overlay.css'
+    'bundles/cmfcreate/css/halloCmfStyle.css'
+    'bundles/cmfcreate/css/createStyle.css'
+    'bundles/cmfcreate/css/overlay.css'
 
 %}
     <link rel="stylesheet" href="{{ asset_url }}" media="screen" type="text/css"/>


### PR DESCRIPTION
The change in symfony-cmf/CreateBundle#52 broke every existing asset path.
