### PR TITLE
fixed object vs array serialization for assets

### DIFF
--- a/Controller/PHPCRImageController.php
+++ b/Controller/PHPCRImageController.php
@@ -48,7 +48,8 @@ class PHPCRImageController extends ImageController
         $query = $this->manager->createQuery($sql, QueryInterface::JCR_SQL2);
         $query->setFirstResult($offset);
         $query->setMaxResults($limit);
-        return $this->manager->getDocumentsByPhpcrQuery($query->getPhpcrQuery());
+
+        return array_values($this->manager->getDocumentsByPhpcrQuery($query->getPhpcrQuery())->toArray());
     }
 
     protected function getImagesByTag(array $tags, $offset, $limit)
@@ -68,6 +69,7 @@ class PHPCRImageController extends ImageController
         $query = $this->manager->createQuery($sql, QueryInterface::JCR_SQL2);
         $query->setFirstResult($offset);
         $query->setMaxResults($limit);
-        return $this->manager->getDocumentsByPhpcrQuery($query->getPhpcrQuery());
+
+        return array_values($this->manager->getDocumentsByPhpcrQuery($query->getPhpcrQuery())->toArray());
     }
 }


### PR DESCRIPTION
since the javascript code from the `hallo-editor` expects an array for the `assets`  (it uses `shift` which is only available for arrays) and an array collection get serialized to an object, the search functionality is currently broken.

This PR fixes this, so that it is ensured it is an array.

**before:**

``` json
{
  /cms/content/static/foo : {id: '/cms/content/static/foo', alt:'foo', url: '/foo'},
  /cms/content/static/bar : {id: '/cms/content/static/bar', alt:'bar', url: '/bar'}
}
```

**after**

``` json
[
  {id: '/cms/content/static/foo', alt:'foo', url: '/foo'},
  {id: '/cms/content/static/bar', alt:'bar', url: '/bar'}
]
```
