### PR TITLE
ensure that the request locale is used

### DIFF
--- a/Resources/views/includejsfiles-create.html.twig
+++ b/Resources/views/includejsfiles-create.html.twig
@@ -9,7 +9,7 @@
     cmfCreateHalloImageSearch = '{{ path('cmf_create_image_search') }}';
     cmfCreateHalloLinkRelatedPath = '{{ path('cmf_create_image_related') }}';
     {%  endif %}
-    var cmfCreatePutDocument = '{{ path('cmf_create_put_document_base') }}';
+    var cmfCreatePutDocument = '{{ path('cmf_create_put_document_base', {'_locale': app.request.locale}) }}';
     var cmfCreateStanbolUrl = '{{ cmfCreateStanbolUrl }}';
 
     {%  if cmfCreateHalloFixedToolbar %}


### PR DESCRIPTION
honestly I am not quite sure why I need to explicitly pass the locale, but otherwise it seems to always use the default locale.
