### PR TITLE
Disable image when disabled

### DIFF
--- a/DependencyInjection/CmfCreateExtension.php
+++ b/DependencyInjection/CmfCreateExtension.php
@@ -83,6 +83,8 @@ class CmfCreateExtension extends Extension
             $container->setParameter($this->getAlias() . '.persistence.phpcr.image.class', $config['image']['model_class']);
             $container->setParameter($this->getAlias() . '.persistence.phpcr.image_controller.class', $config['image']['controller_class']);
             $container->setParameter($this->getAlias() . '.persistence.phpcr.image_basepath', $config['image']['basepath']);
+        } else {
+            $container->setParameter($this->getAlias() . '.image_enabled', false);
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Previously, when phpcr was enabled, but image disabled, the executing will
fail because cmf_core.image_enabled did not exists.
