### PR TITLE
properly separate persistence specific and general things

### DIFF
--- a/CmfCreateBundle.php
+++ b/CmfCreateBundle.php
@@ -2,8 +2,17 @@
 
 namespace Symfony\Cmf\Bundle\CreateBundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class CmfCreateBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        if ($container->hasExtension('jms_di_extra')) {
+            $container->getExtension('jms_di_extra')->blackListControllerFile(__DIR__ . '/Controller/ImageController.php');
+        }
+    }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('auto_mapping')->defaultTrue()->end()
+                ->scalarNode('object_mapper_service_id')->defaultNull()->end()
 
                 ->arrayNode('persistence')
                     ->addDefaultsIfNotSet()

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -7,9 +7,6 @@
     <parameters>
         <parameter key="cmf_create.persistence.phpcr.manager_name">null</parameter>
         <parameter key="cmf_create.persistence.phpcr.odm_mapper.class">Midgard\CreatePHP\Mapper\DoctrinePhpcrOdmMapper</parameter>
-        <parameter key="cmf_create.rest.controller.class">Symfony\Cmf\Bundle\CreateBundle\Controller\RestController</parameter>
-        <parameter key="cmf_create.rdf_type_factory_class">Midgard\CreatePHP\Metadata\RdfTypeFactory</parameter>
-        <parameter key="cmf_create.rest.handler_class">Midgard\CreatePHP\RestService</parameter>
     </parameters>
 
     <services>
@@ -18,25 +15,6 @@
             <argument>%cmf_create.map%</argument>
             <argument type="service" id="doctrine_phpcr"/>
             <argument>%cmf_create.persistence.phpcr.manager_name%</argument>
-        </service>
-
-        <service id="cmf_create.rdf_type_factory" class="%cmf_create.rdf_type_factory_class%" public="true">
-            <argument type="service" id="cmf_create.persistence.phpcr.object_mapper"/>
-            <argument type="service" id="cmf_create.rdf_driver"/>
-            <argument>%cmf_create.map%</argument>
-        </service>
-
-        <service id="cmf_create.rest.controller" class="%cmf_create.rest.controller.class%">
-            <argument type="service" id="fos_rest.view_handler"/>
-            <argument type="service" id="cmf_create.persistence.phpcr.object_mapper"/>
-            <argument type="service" id="cmf_create.rdf_type_factory"/>
-            <argument type="service" id="cmf_create.rest.handler"/>
-            <argument>%cmf_create.role%</argument>
-            <argument type="service" id="security.context" on-invalid="ignore"/>
-        </service>
-
-        <service id="cmf_create.rest.handler" class="%cmf_create.rest.handler_class%" public="true">
-            <argument type="service" id="cmf_create.persistence.phpcr.object_mapper"/>
         </service>
 
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,12 @@
 
     <parameters>
         <parameter key="cmf_create.jsloader.controller.class">Symfony\Cmf\Bundle\CreateBundle\Controller\JsloaderController</parameter>
+        <parameter key="cmf_create.rest.controller.class">Symfony\Cmf\Bundle\CreateBundle\Controller\RestController</parameter>
+        <parameter key="cmf_create.rdf_type_factory_class">Midgard\CreatePHP\Metadata\RdfTypeFactory</parameter>
+        <parameter key="cmf_create.rest.handler_class">Midgard\CreatePHP\RestService</parameter>
+        <parameter key="cmf_create.twig_extension.class">Midgard\CreatePHP\Extension\Twig\CreatephpExtension</parameter>
+        <parameter key="cmf_create.twig_extension.class">Midgard\CreatePHP\Extension\Twig\CreatephpExtension</parameter>
+        <parameter key="cmf_create.rdf_driver.class">Midgard\CreatePHP\Metadata\RdfDriverXml</parameter>
     </parameters>
 
     <services>
@@ -21,13 +27,32 @@
             <argument type="service" id="cmf_media.browser_file_helper" on-invalid="ignore"/>
         </service>
 
-        <service id="cmf_create.twig_extension" class="Midgard\CreatePHP\Extension\Twig\CreatephpExtension">
+        <service id="cmf_create.twig_extension" class="%cmf_create.twig_extension.class%">
             <argument type="service" id="cmf_create.rdf_type_factory"/>
             <tag name="twig.extension"/>
         </service>
 
-        <service id="cmf_create.rdf_driver" class="Midgard\CreatePHP\Metadata\RdfDriverXml">
+        <service id="cmf_create.rdf_driver" class="%cmf_create.rdf_driver.class%">
             <argument>%cmf_create.rdf_config_dirs%</argument>
+        </service>
+
+        <service id="cmf_create.rdf_type_factory" class="%cmf_create.rdf_type_factory_class%" public="true">
+            <argument type="service" id="cmf_create.object_mapper"/>
+            <argument type="service" id="cmf_create.rdf_driver"/>
+            <argument>%cmf_create.map%</argument>
+        </service>
+
+        <service id="cmf_create.rest.controller" class="%cmf_create.rest.controller.class%">
+            <argument type="service" id="fos_rest.view_handler"/>
+            <argument type="service" id="cmf_create.object_mapper"/>
+            <argument type="service" id="cmf_create.rdf_type_factory"/>
+            <argument type="service" id="cmf_create.rest.handler"/>
+            <argument>%cmf_create.role%</argument>
+            <argument type="service" id="security.context" on-invalid="ignore"/>
+        </service>
+
+        <service id="cmf_create.rest.handler" class="%cmf_create.rest.handler_class%" public="true">
+            <argument type="service" id="cmf_create.object_mapper"/>
         </service>
 
     </services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

This will validate the configuration to actually tell you when you try to use the bundle without any provided or custom object mapper. Moving all the configuration that is not storage dependent out of the perstistence-phpcr config file.
