### PR TITLE
[Security] - replace performSecurityChecks() by AccessCheckerInterface

### DIFF
--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -146,7 +146,9 @@ class RestController
      */
     public function deleteDocumentAction(Request $request, $subject)
     {
-        $this->performSecurityChecks();
+        if (!$this->accessChecker->check($request)) {
+            throw new AccessDeniedException();
+        }
 
         $model = $this->getModelBySubject($request, $subject);
         $type = $this->typeFactory->getTypeByObject($model);
@@ -166,7 +168,9 @@ class RestController
      */
     public function workflowsAction(Request $request, $subject)
     {
-        $this->performSecurityChecks();
+        if (!$this->accessChecker->check($request)) {
+            throw new AccessDeniedException();
+        }
 
         $result = $this->restHandler->getWorkflows($subject);
         $view = View::create($result)->setFormat('json');
@@ -177,6 +181,7 @@ class RestController
     /**
      * Check if the action can be performed
      *
+     * @deprecated keep it to preserve BC
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */
     protected function performSecurityChecks()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Hi guys, 

seems `$this->securityContext` is not injected into [RestController](https://github.com/symfony-cmf/CreateBundle/blob/master/Controller/RestController.php#L67). Check security cannot be operated, prefer use `$this->accessChecker` which have `SecurityContext`
