### PR TITLE
remove deprecated method that was allowing everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+
+1.1.0-RC3
+---------
+
+* **2014-04-27**: Security was refactored to work consistently and reliably.
+  The RestController::performSecurityChecks method was removed and replaced
+  with the AccessCheckerInterface service. The configuration did not need to
+  be changed.
+
 1.1.0-RC2
 ---------
 

--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -16,7 +16,6 @@ use Symfony\Cmf\Bundle\CreateBundle\Security\AccessCheckerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ -25,7 +24,6 @@ use FOS\RestBundle\View\View;
 use Midgard\CreatePHP\Metadata\RdfTypeFactory;
 use Midgard\CreatePHP\RestService;
 use Midgard\CreatePHP\RdfMapperInterface;
-use Midgard\CreatePHP\Helper\NamespaceHelper;
 
 /**
  * Controller to handle content update callbacks.
@@ -179,15 +177,16 @@ class RestController
     }
 
     /**
-     * Check if the action can be performed
+     * DEPRECATED: Check if the action can be performed.
      *
-     * @deprecated keep it to preserve BC
-     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @deprecated use $this->accessChecker->check instead. This method always
+     *             denies access.
+     *
+     * @throws AccessDeniedException Always denies access.
      */
     protected function performSecurityChecks()
     {
-        if ($this->securityContext && false === $this->securityContext->isGranted($this->requiredRole)) {
-            throw new AccessDeniedException();
-        }
+        throw new AccessDeniedException();
     }
+
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Follow-up on #103 by @cbastienbaron - i prefer to do a BC break over leaving a basically non-functioning method in place that can lead to severe security issues.

I think the reason this method turned up again was a merge conflict between the workflow and delete actions and the refactoring to the new way to do security checks.
