### PR TITLE
[WIP] Fixed bugs when Symfony is not in the root

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('stanbol_url')->defaultValue('http://dev.iks-project.eu:8081')->end()
                 ->booleanNode('fixed_toolbar')->defaultTrue()->end()
-                ->scalarNode('editor_base_path')->defaultValue('/bundles/cmfcreate/vendor/ckeditor/')->end()
+                ->scalarNode('editor_base_path')->defaultValue('bundles/cmfcreate/vendor/ckeditor/')->end()
                 ->arrayNode('plain_text_types')
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()

--- a/Resources/views/includejsfiles-ckeditor.html.twig
+++ b/Resources/views/includejsfiles-ckeditor.html.twig
@@ -1,6 +1,6 @@
 {% include "CmfCreateBundle::includejsfiles-create.html.twig" %}
 
-<script>window.CKEDITOR_BASEPATH = '{{ cmfCreateEditorBasePath }}';</script>
+<script>window.CKEDITOR_BASEPATH = '{{ asset(cmfCreateEditorBasePath) }}';</script>
 {% javascripts output="/js/ckeditor.js"
     '@CmfCreateBundle/Resources/public/vendor/ckeditor/ckeditor.js'
     '@CmfCreateBundle/Resources/public/js/init-create-ckeditor.js'


### PR DESCRIPTION
This fixes the CKEDITOR when Symfony is not installed in the root.

There is one thing left:
- [ ] The link to the createbundle.png file is absolute, so it doesn't work. However, we can't use twig's `asset()` function in a stylesheet.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
