### PR TITLE
Fix broken ckeditor paths

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('stanbol_url')->defaultValue('http://dev.iks-project.eu:8081')->end()
                 ->booleanNode('fixed_toolbar')->defaultTrue()->end()
-                ->scalarNode('editor_base_path')->defaultValue('bundles/cmfcreate/vendor/ckeditor/')->end()
+                ->scalarNode('editor_base_path')->defaultValue('/bundles/cmfcreate/vendor/ckeditor/')->end()
                 ->arrayNode('plain_text_types')
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()

--- a/Resources/views/includejsfiles-ckeditor.html.twig
+++ b/Resources/views/includejsfiles-ckeditor.html.twig
@@ -1,6 +1,6 @@
 {% include "CmfCreateBundle::includejsfiles-create.html.twig" %}
 
-<script>window.CKEDITOR_BASEPATH = '{{ asset(cmfCreateEditorBasePath) }}';</script>
+<script>window.CKEDITOR_BASEPATH = '{{ app.request.basePath }}{{ cmfCreateEditorBasePath }}';</script>
 {% javascripts output="js/ckeditor.js"
     '@CmfCreateBundle/Resources/public/vendor/ckeditor/ckeditor.js'
     '@CmfCreateBundle/Resources/public/js/init-create-ckeditor.js'


### PR DESCRIPTION
Hopefully fixes two issues:
1. PR #105 introduced an issue when the assets_version is set (the assets_version was getting appended to the path)
2. ckeditor javascript paths were broken when Symfony is non-root. Assetic appeared to ignore the subdirectory symfony was installed to, but removing the leading / in the output seems to have fixed that for non-root installations (I haven't tested when installed to root)
