### PR TITLE
Update .gitignore to only ignore root vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-vendor/
+/vendor/
 Resources/public/vendor/create
 Resources/public/vendor/hallo
 Resources/public/vendor/ckeditor


### PR DESCRIPTION
With ignoring the vendor as it was it was causing the Resource/public/vendor to be ignored as well. While this isn't a problem most of the time, I've created a satis repository and when it archives the CreateBundle it skips over files in the .gitignore. Without the resources/public/vendor directory the checkout scripts fail.
