### PR TITLE
make rest controller more generic to support additional workflows

### DIFF
--- a/Resources/config/routing/rest.xml
+++ b/Resources/config/routing/rest.xml
@@ -4,24 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="cmf_create_put_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
-        <default key="_controller">cmf_create.rest.controller:putDocumentAction</default>
-        <default key="_format">json</default>
-        <requirement key="subject">.+</requirement>
-        <requirement key="_method">PUT</requirement>
-    </route>
-
     <route id="cmf_create_post_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
         <default key="_controller">cmf_create.rest.controller:postDocumentAction</default>
         <default key="_format">json</default>
         <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="cmf_create_delete_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
-        <default key="_controller">cmf_create.rest.controller:deleteDocumentAction</default>
+    <route id="cmf_create_put_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
+        <default key="_controller">cmf_create.rest.controller:updateDocumentAction</default>
         <default key="_format">json</default>
         <requirement key="subject">.+</requirement>
-        <requirement key="_method">DELETE</requirement>
     </route>
 
     <route id="cmf_create_workflows" pattern="/{_locale}/symfony-cmf/create/workflows/{subject}">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #116 |
| License | MIT |
| Doc PR | TODO |

/cc @uwej711 

btw for the doc, this is using symfony http handling, meanign X-HTTP-Method-Override is supported as well. when documenting this we should make sure to explain the different ways to configure which workflows should be available (firewall, route, access checker).
