### PR TITLE
make it possible to always force the current request locale to be set on the model

### DIFF
--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\CreateBundle\Controller;
 
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
 use Symfony\Cmf\Bundle\CreateBundle\Security\AccessCheckerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -55,24 +56,32 @@ class RestController
     protected $accessChecker;
 
     /**
+     * @var boolean
+     */
+    protected $forceRequestLocale;
+
+    /**
      * @param ViewHandlerInterface   $viewHandler
      * @param RdfMapperInterface     $rdfMapper
      * @param RdfTypeFactory         $typeFactory
      * @param RestService            $restHandler
      * @param AccessCheckerInterface $accessChecker
+     * @param boolean                $forceRequestLocale
      */
     public function __construct(
         ViewHandlerInterface $viewHandler,
         RdfMapperInterface $rdfMapper,
         RdfTypeFactory $typeFactory,
         RestService $restHandler,
-        AccessCheckerInterface $accessChecker
+        AccessCheckerInterface $accessChecker,
+        $forceRequestLocale
     ) {
         $this->viewHandler = $viewHandler;
         $this->rdfMapper = $rdfMapper;
         $this->typeFactory = $typeFactory;
         $this->restHandler = $restHandler;
         $this->accessChecker = $accessChecker;
+        $this->forceRequestLocale = $forceRequestLocale;
     }
 
     protected function getModelBySubject(Request $request, $subject)
@@ -80,6 +89,10 @@ class RestController
         $model = $this->rdfMapper->getBySubject($subject);
         if (empty($model)) {
             throw new NotFoundHttpException($subject.' not found');
+        }
+
+        if ($this->forceRequestLocale && $model instanceof TranslatableInterface) {
+            $model->setLocale($request->getLocale());
         }
 
         return $model;

--- a/DependencyInjection/CmfCreateExtension.php
+++ b/DependencyInjection/CmfCreateExtension.php
@@ -76,6 +76,14 @@ class CmfCreateExtension extends Extension
             $container->setParameter($this->getAlias().'.rest.controller.class', $config['rest_controller_class']);
         }
 
+        if ($config['rest_force_request_locale']) {
+            $bundles = $container->getParameter('kernel.bundles');
+            if (!isset($bundles['CmfCoreBundle'])) {
+                throw new InvalidConfigurationException('You need to enable "CmfCoreBundle" when activating the "rest_force_request_locale" option');
+            }
+        }
+        $container->setParameter($this->getAlias().'.rest.force_request_locale', $config['rest_force_request_locale']);
+
         $this->loadSecurity($config['security'], $loader, $container);
 
         $hasMapper = false;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('rdf_config_dir', 'rdf_config_dirs')
             ->children()
                 ->scalarNode('rest_controller_class')->defaultFalse()->end()
+                ->booleanNode('rest_force_request_locale')->defaultFalse()->end()
                 ->arrayNode('map')
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -48,6 +48,7 @@
             <argument type="service" id="cmf_create.rdf_type_factory"/>
             <argument type="service" id="cmf_create.rest.handler"/>
             <argument type="service" id="cmf_create.security.checker"/>
+            <argument>%cmf_create.rest.force_request_locale%</argument>
         </service>
 
         <service id="cmf_create.security.role_access_checker" class="%cmf_create.security.role_access_checker.class%">

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony-cmf/testing": "~1.1"
     },
     "suggest": {
+        "symfony-cmf/core-bundle": "To be able to enable 'rest_force_request_locale', ~1.0",
         "symfony-cmf/media-bundle": "When using the default image support, ~1.1"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/557 |
