### PR TITLE
Remove locale prefix from rest routes

### DIFF
--- a/Resources/config/routing/rest.xml
+++ b/Resources/config/routing/rest.xml
@@ -4,38 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="cmf_create_put_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
-        <default key="_controller">cmf_create.rest.controller:putDocumentAction</default>
-        <default key="_format">json</default>
-        <requirement key="subject">.+</requirement>
-        <requirement key="_method">PUT</requirement>
-    </route>
-
-    <route id="cmf_create_post_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
-        <default key="_controller">cmf_create.rest.controller:postDocumentAction</default>
-        <default key="_format">json</default>
-        <requirement key="_method">POST</requirement>
-    </route>
-
-    <route id="cmf_create_delete_document" pattern="/{_locale}/symfony-cmf/create/document/{subject}">
-        <default key="_controller">cmf_create.rest.controller:deleteDocumentAction</default>
-        <default key="_format">json</default>
-        <requirement key="subject">.+</requirement>
-        <requirement key="_method">DELETE</requirement>
-    </route>
-
-    <route id="cmf_create_workflows" pattern="/{_locale}/symfony-cmf/create/workflows/{subject}">
-        <default key="_controller">cmf_create.rest.controller:workflowsAction</default>
-        <default key="_format">json</default>
-        <requirement key="subject">.+</requirement>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <!--
-      a variant of above routes that would not work but can be used to concatenate actual routes in javascript
-      this route should never be used from the outside, only to be used inside "includejsfiles-create.html.twig
-    -->
-    <route id="cmf_create_put_document_base" pattern="/{_locale}/symfony-cmf/create/document" />
-    <route id="cmf_create_workflows_base" pattern="/{_locale}/symfony-cmf/create/workflows" />
-
+    <import resource="rest_no_locale.xml" prefix="/{_locale}" />
 </routes>

--- a/Resources/config/routing/rest_no_locale.xml
+++ b/Resources/config/routing/rest_no_locale.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="cmf_create_put_document" pattern="/symfony-cmf/create/document/{subject}">
+        <default key="_controller">cmf_create.rest.controller:putDocumentAction</default>
+        <default key="_format">json</default>
+        <requirement key="subject">.+</requirement>
+        <requirement key="_method">PUT</requirement>
+    </route>
+
+    <route id="cmf_create_post_document" pattern="/symfony-cmf/create/document/{subject}">
+        <default key="_controller">cmf_create.rest.controller:postDocumentAction</default>
+        <default key="_format">json</default>
+        <requirement key="_method">POST</requirement>
+    </route>
+
+    <route id="cmf_create_delete_document" pattern="/symfony-cmf/create/document/{subject}">
+        <default key="_controller">cmf_create.rest.controller:deleteDocumentAction</default>
+        <default key="_format">json</default>
+        <requirement key="subject">.+</requirement>
+        <requirement key="_method">DELETE</requirement>
+    </route>
+
+    <route id="cmf_create_workflows" pattern="/symfony-cmf/create/workflows/{subject}">
+        <default key="_controller">cmf_create.rest.controller:workflowsAction</default>
+        <default key="_format">json</default>
+        <requirement key="subject">.+</requirement>
+        <requirement key="_method">GET</requirement>
+    </route>
+
+    <!--
+      a variant of above routes that would not work but can be used to concatenate actual routes in javascript
+      this route should never be used from the outside, only to be used inside "includejsfiles-create.html.twig
+    -->
+    <route id="cmf_create_put_document_base" pattern="/symfony-cmf/create/document" />
+    <route id="cmf_create_workflows_base" pattern="/symfony-cmf/create/workflows" />
+
+</routes>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR | To come |

I think the `_locale` prefix should (or not) be set globally when importing the `rest.xml` file.

I personnaly have one domain per locale so I don't need to prefix these routes.

If this PR is accepted, I will add the corresponding documentation.

BTW, I submit this PR against the 1.1 branch, hope it's ok !
